### PR TITLE
Fixed bug causing PdfSmartCopy to crash

### DIFF
--- a/itext/itext.kernel/itext/kernel/pdf/PdfWriter.cs
+++ b/itext/itext.kernel/itext/kernel/pdf/PdfWriter.cs
@@ -548,7 +548,7 @@ namespace iText.Kernel.Pdf {
                     return;
                 }
                 PdfName[] keys = new PdfName[dic.KeySet().Count];
-                dic.KeySet().ToArray(keys);
+                keys = dic.KeySet().ToArray(keys);
                 iText.IO.Util.JavaUtil.Sort(keys);
                 foreach (Object key in keys) {
                     if (key.Equals(PdfName.P) && (dic.Get((PdfName)key).IsIndirectReference() || dic.Get((PdfName)key).IsDictionary


### PR DESCRIPTION
If Smart Copy was turned on, the writer would throw a
NullPointerException. The issue was that the keys array was not being
assigned the value returned from dic.KeySet().ToArray(keys). This fixes
smart copy.