### PR TITLE
Don't try to get location of dynamic (in-memory) assemblies

### DIFF
--- a/itext/itext.io/itext/io/util/ResourceUtil.cs
+++ b/itext/itext.io/itext/io/util/ResourceUtil.cs
@@ -202,7 +202,7 @@ namespace iText.IO.Util {
 
         private static void LoadITextResourceAssemblies() {
 #if !NETSTANDARD1_6
-            var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies().ToList();
+            var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies().Where( a=> !a.IsDynamic).ToList();
             var loadedPaths = loadedAssemblies.Select(a => a.Location).ToArray();
             
             var referencedPaths = Directory.GetFiles(FileUtil.GetBaseDirectory(), "*.dll");


### PR DESCRIPTION
When iText tries to locate fonts embedded in resources it enumerates all assemblies in the current domain. ASP.Net generates assemblies in memory. The Location property generates an exception when it is accessed on in-memory assemblies.
This change excludes dynamic assemblies from the search.