### PR TITLE
Path transformation to userspace

### DIFF
--- a/itext.tests/itext.kernel.tests/itext/kernel/geom/BezierCurveTest.cs
+++ b/itext.tests/itext.kernel.tests/itext/kernel/geom/BezierCurveTest.cs
@@ -1,0 +1,65 @@
+﻿/*
+This file is part of the iText (R) project.
+Copyright (c) 1998-2018 iText Group NV
+Authors: iText Software.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License version 3
+as published by the Free Software Foundation with the addition of the
+following permission added to Section 15 as permitted in Section 7(a):
+FOR ANY PART OF THE COVERED WORK IN WHICH THE COPYRIGHT IS OWNED BY
+ITEXT GROUP. ITEXT GROUP DISCLAIMS THE WARRANTY OF NON INFRINGEMENT
+OF THIRD PARTY RIGHTS
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU Affero General Public License for more details.
+You should have received a copy of the GNU Affero General Public License
+along with this program; if not, see http://www.gnu.org/licenses or write to
+the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+Boston, MA, 02110-1301 USA, or download the license from the following URL:
+http://itextpdf.com/terms-of-use/
+
+The interactive user interfaces in modified source and object code versions
+of this program must display Appropriate Legal Notices, as required under
+Section 5 of the GNU Affero General Public License.
+
+In accordance with Section 7(b) of the GNU Affero General Public License,
+a covered work must retain the producer line in every PDF that is created
+or manipulated using iText.
+
+You can be released from the requirements of the license by purchasing
+a commercial license. Buying such a license is mandatory as soon as you
+develop commercial activities involving the iText software without
+disclosing the source code of your own applications.
+These activities include: offering paid services to customers as an ASP,
+serving PDFs on the fly in a web application, shipping iText with a closed
+source product.
+
+For more information, please contact iText Software Corp. at this
+address: sales@itextpdf.com
+*/
+using System.Collections.Generic;
+using iText.Kernel;
+using iText.Kernel.Pdf;
+using iText.Test;
+
+namespace iText.Kernel.Geom
+{
+    public class BezierCurveTest : ExtendedITextTest
+    {
+        [NUnit.Framework.Test]
+        public virtual void BezierCurveUserSpaceTransformTest()
+        {
+            BezierCurve curve = new BezierCurve(new List<Point> {
+                new Point(4, 4), new Point(7,7), new Point(10, 0), new Point(0, 0) });
+            Matrix m1 = new Matrix(1, 0, 0, 1, 40, 40);
+            IShape shouldBe = new BezierCurve(new List<Point> {
+                new Point(44, 44), new Point(47, 47), new Point(50, 40), new Point(40, 40) });
+            IShape result = curve.TransformToUserspace(m1);
+
+            NUnit.Framework.Assert.AreEqual(result.GetBasePoints(), shouldBe.GetBasePoints());
+        }
+    }
+}

--- a/itext.tests/itext.kernel.tests/itext/kernel/geom/LineTest.cs
+++ b/itext.tests/itext.kernel.tests/itext/kernel/geom/LineTest.cs
@@ -1,0 +1,63 @@
+﻿/*
+This file is part of the iText (R) project.
+Copyright (c) 1998-2018 iText Group NV
+Authors: iText Software.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License version 3
+as published by the Free Software Foundation with the addition of the
+following permission added to Section 15 as permitted in Section 7(a):
+FOR ANY PART OF THE COVERED WORK IN WHICH THE COPYRIGHT IS OWNED BY
+ITEXT GROUP. ITEXT GROUP DISCLAIMS THE WARRANTY OF NON INFRINGEMENT
+OF THIRD PARTY RIGHTS
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU Affero General Public License for more details.
+You should have received a copy of the GNU Affero General Public License
+along with this program; if not, see http://www.gnu.org/licenses or write to
+the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+Boston, MA, 02110-1301 USA, or download the license from the following URL:
+http://itextpdf.com/terms-of-use/
+
+The interactive user interfaces in modified source and object code versions
+of this program must display Appropriate Legal Notices, as required under
+Section 5 of the GNU Affero General Public License.
+
+In accordance with Section 7(b) of the GNU Affero General Public License,
+a covered work must retain the producer line in every PDF that is created
+or manipulated using iText.
+
+You can be released from the requirements of the license by purchasing
+a commercial license. Buying such a license is mandatory as soon as you
+develop commercial activities involving the iText software without
+disclosing the source code of your own applications.
+These activities include: offering paid services to customers as an ASP,
+serving PDFs on the fly in a web application, shipping iText with a closed
+source product.
+
+For more information, please contact iText Software Corp. at this
+address: sales@itextpdf.com
+*/
+using System.Collections.Generic;
+using iText.Kernel;
+using iText.Kernel.Pdf;
+using iText.Test;
+
+namespace iText.Kernel.Geom
+{
+    public class LineTest : ExtendedITextTest
+    {
+        [NUnit.Framework.Test]
+        public virtual void LineUserSpaceTransformTest()
+        {
+            Line line1 = new Line(0, 0, 20, 20);
+            Matrix m1 = new Matrix(1, 0, 0, 1, 40, 40);
+            IShape shouldBe = new Line(40, 40, 60, 60);
+            IShape result = line1.TransformToUserspace(m1);
+            
+            NUnit.Framework.Assert.AreEqual(result.GetBasePoints(), shouldBe.GetBasePoints());
+        }
+    }
+}

--- a/itext.tests/itext.kernel.tests/itext/kernel/geom/PathTest.cs
+++ b/itext.tests/itext.kernel.tests/itext/kernel/geom/PathTest.cs
@@ -1,0 +1,85 @@
+﻿/*
+This file is part of the iText (R) project.
+Copyright (c) 1998-2018 iText Group NV
+Authors: iText Software.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License version 3
+as published by the Free Software Foundation with the addition of the
+following permission added to Section 15 as permitted in Section 7(a):
+FOR ANY PART OF THE COVERED WORK IN WHICH THE COPYRIGHT IS OWNED BY
+ITEXT GROUP. ITEXT GROUP DISCLAIMS THE WARRANTY OF NON INFRINGEMENT
+OF THIRD PARTY RIGHTS
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU Affero General Public License for more details.
+You should have received a copy of the GNU Affero General Public License
+along with this program; if not, see http://www.gnu.org/licenses or write to
+the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+Boston, MA, 02110-1301 USA, or download the license from the following URL:
+http://itextpdf.com/terms-of-use/
+
+The interactive user interfaces in modified source and object code versions
+of this program must display Appropriate Legal Notices, as required under
+Section 5 of the GNU Affero General Public License.
+
+In accordance with Section 7(b) of the GNU Affero General Public License,
+a covered work must retain the producer line in every PDF that is created
+or manipulated using iText.
+
+You can be released from the requirements of the license by purchasing
+a commercial license. Buying such a license is mandatory as soon as you
+develop commercial activities involving the iText software without
+disclosing the source code of your own applications.
+These activities include: offering paid services to customers as an ASP,
+serving PDFs on the fly in a web application, shipping iText with a closed
+source product.
+
+For more information, please contact iText Software Corp. at this
+address: sales@itextpdf.com
+*/
+using System.Collections.Generic;
+using iText.Kernel;
+using iText.Kernel.Pdf;
+using iText.Test;
+
+namespace iText.Kernel.Geom
+{
+    public class PathTest : ExtendedITextTest
+    {
+        [NUnit.Framework.Test]
+        public virtual void PathUserSpaceTransformTest()
+        {
+            Subpath subpath = new Subpath();
+            subpath.AddSegment(new Line(0, 0, 10, 10));
+            List<Subpath> subPaths = new List<Subpath>() { subpath };
+            Path path = new Path(subPaths);
+            Matrix m1 = new Matrix(1, 0, 0, 1, 40, 40);
+
+            Subpath subpathShouldBe = new Subpath();
+            subpathShouldBe.AddSegment(new Line(40, 40, 50, 50));
+            Path shouldBe = new Path(new List<Subpath>() { subpathShouldBe });
+            Path result = path.TransformPath(m1);
+
+            NUnit.Framework.Assert.AreEqual(result.GetSubpaths().Count, shouldBe.GetSubpaths().Count);
+            IList<Subpath> resultSubPaths = result.GetSubpaths();
+            IList<Subpath> shouldBeSubPaths = shouldBe.GetSubpaths();
+
+            for (int i = 0; i < resultSubPaths.Count; i++)
+            {
+                IList<IShape> resultSegments = resultSubPaths[i].GetSegments();
+                IList<IShape> shouldBeSegments = shouldBeSubPaths[i].GetSegments();
+                NUnit.Framework.Assert.AreEqual(resultSegments.Count, shouldBeSegments.Count);
+                NUnit.Framework.Assert.AreEqual(resultSubPaths[i].IsClosed(), shouldBeSubPaths[i].IsClosed());
+
+                for (int j = 0; j < resultSegments.Count; j++)
+                {
+                    NUnit.Framework.Assert.AreEqual(resultSegments[j].GetType(), shouldBeSegments[j].GetType());
+                    NUnit.Framework.Assert.AreEqual(resultSegments[j].GetBasePoints(), shouldBeSegments[j].GetBasePoints());
+                }
+            }
+        }
+    }
+}

--- a/itext/itext.kernel/itext/kernel/geom/BezierCurve.cs
+++ b/itext/itext.kernel/itext/kernel/geom/BezierCurve.cs
@@ -167,5 +167,33 @@ namespace iText.Kernel.Geom {
             RecursiveApproximation(x1, y1, x12, y12, x123, y123, x1234, y1234, points);
             RecursiveApproximation(x1234, y1234, x234, y234, x34, y34, x4, y4, points);
         }
+        
+        /// <summary>
+        /// Transforms the bezierCurve by the specified matrix
+        /// </summary>
+        /// <param name="ctm">the matrix for the transformation</param>
+        /// <returns>the transformed bezierCurve</returns>
+        public IShape TransformToUserspace(Matrix ctm)
+        {
+            try
+            {
+                IShape transformedCurve;
+                IList<Point> basePts = controlPoints;
+                Point[] points = basePts.ToArray(new Point[basePts.Count]);
+
+                AffineTransform t = new AffineTransform(ctm.Get(Matrix.I11), ctm.Get(Matrix
+                    .I12), ctm.Get(Matrix.I21), ctm.Get(Matrix.I22), ctm.Get(Matrix.I31), ctm.Get(Matrix.I32));
+                //t = t.CreateInverse();
+                Point[] transformed = new Point[points.Length];
+                t.Transform(points, 0, transformed, 0, points.Length);
+                transformedCurve = new BezierCurve(iText.IO.Util.JavaUtil.ArraysAsList(transformed));
+
+                return transformedCurve;
+            }
+            catch (Exception e)
+            {
+                throw new Exception(e.Message, e);
+            }
+        }
     }
 }

--- a/itext/itext.kernel/itext/kernel/geom/IShape.cs
+++ b/itext/itext.kernel/itext/kernel/geom/IShape.cs
@@ -58,5 +58,12 @@ namespace iText.Kernel.Geom {
         /// consisting of shape's base points.
         /// </returns>
         IList<Point> GetBasePoints();
+        
+        /// <summary>
+        /// Transforms the shape by the specified matrix
+        /// </summary>
+        /// <param name="ctm">the matrix for the transformation</param>
+        /// <returns>the transformed shape</returns>
+        IShape TransformToUserspace(Matrix ctm);
     }
 }

--- a/itext/itext.kernel/itext/kernel/geom/Line.cs
+++ b/itext/itext.kernel/itext/kernel/geom/Line.cs
@@ -41,6 +41,7 @@ source product.
 For more information, please contact iText Software Corp. at this
 address: sales@itextpdf.com
 */
+using System;
 using System.Collections.Generic;
 
 namespace iText.Kernel.Geom {
@@ -77,6 +78,34 @@ namespace iText.Kernel.Geom {
             basePoints.Add(p1);
             basePoints.Add(p2);
             return basePoints;
+        }
+        
+        /// <summary>
+        /// Transforms the line by the specified matrix
+        /// </summary>
+        /// <param name="ctm">the matrix for the transformation</param>
+        /// <returns>the transformed line</returns>
+        public IShape TransformToUserspace(Matrix ctm)
+        {
+            try
+            {
+                IShape transformedLine;
+                IList<Point> basePoints = GetBasePoints();
+                Point[] points = basePoints.ToArray(new Point[basePoints.Count]);
+
+                AffineTransform t = new AffineTransform(ctm.Get(Matrix.I11), ctm.Get(Matrix
+                    .I12), ctm.Get(Matrix.I21), ctm.Get(Matrix.I22), ctm.Get(Matrix.I31), ctm.Get(Matrix.I32));
+                //t = t.CreateInverse();
+                Point[] transformed = new Point[points.Length];
+                t.Transform(points, 0, transformed, 0, points.Length);
+                transformedLine = new Line(transformed[0], transformed[1]);
+
+                return transformedLine;
+            }
+            catch (Exception e)
+            {
+                throw new Exception(e.Message, e);
+            }
         }
     }
 }

--- a/itext/itext.kernel/itext/kernel/geom/Path.cs
+++ b/itext/itext.kernel/itext/kernel/geom/Path.cs
@@ -245,9 +245,49 @@ namespace iText.Kernel.Geom {
             return subpaths.Count == 0;
         }
 
+        /// <summary>
+        /// Transforms the path by the specified matrix
+        /// </summary>
+        /// <param name="ctm">the matrix for the transformation</param>
+        /// <returns>the transformed path</returns>
+        public Path TransformPath(Matrix ctm)
+        {
+            Path transformedPath = new Path();
+            foreach (Subpath subpath in subpaths)
+            {
+                Subpath transformedSubpath = TransformSubpath(subpath, ctm);
+                if (transformedSubpath != null)
+                {
+                    transformedPath.AddSubpath(transformedSubpath);
+                }
+            }
+            return transformedPath;
+        }
+        
         private Subpath GetLastSubpath() {
             System.Diagnostics.Debug.Assert(subpaths.Count > 0);
             return subpaths[subpaths.Count - 1];
+        }
+        
+        private Subpath TransformSubpath(Subpath subpath, Matrix ctm)
+        {
+            try
+            {
+                Subpath newSubpath = new Subpath();
+                foreach (IShape segment in subpath.GetSegments())
+                {
+                    IShape transformedSegment = segment.TransformToUserspace(ctm);
+                    newSubpath.AddSegment(transformedSegment);
+                }
+                newSubpath.SetClosed(subpath.IsClosed());
+
+                return newSubpath;
+            }
+            catch (Exception ex)
+            {
+                //TODO log the exception
+                return null;
+            }
         }
     }
 }


### PR DESCRIPTION
There is a clippingpath transformation method in ParserGraphicsState.cs file. Which is a Private method and we cant use it for other any kind of path. So, to extract path(not clipping path) from pdf files we need a path transformation method. This changes allow us to transform extracting path to userspace