### PR TITLE
fix missing index and newlines in cleanup regexes

### DIFF
--- a/itext/itext.kernel/itext/kernel/pdf/canvas/parser/listener/CharacterRenderInfo.cs
+++ b/itext/itext.kernel/itext/kernel/pdf/canvas/parser/listener/CharacterRenderInfo.cs
@@ -83,11 +83,12 @@ namespace iText.Kernel.Pdf.Canvas.Parser.Listener {
                         // we only insert a blank space if the trailing character of the previous string wasn't a space, and the leading character of the current string isn't a space
                         if (chunk.GetLocation().IsAtWordBoundary(lastChunk.GetLocation()) && !chunk.GetText().StartsWith(" ") && !
                             chunk.GetText().EndsWith(" ")) {
-                            sb.Append(' ');
+                            PutCharsWithIndex(" ", i, indexMap, sb);
                         }
                         PutCharsWithIndex(chunk.GetText(), i, indexMap, sb);
                     }
                     else {
+                        PutCharsWithIndex("\n", i, indexMap, sb);
                         PutCharsWithIndex(chunk.GetText(), i, indexMap, sb);
                     }
                 }


### PR DESCRIPTION
This change fixes PdfAutoSweep with RegexBasedCleanupStrategy when the matched string ends or starts with whitespaces. It was failing because indexMap was missing entries for the indexes of those whitespaces so `endIndex` was null here: https://github.com/itext/itext7-dotnet/blob/d61720c229f428dd075f3ff677d8ca78a00ffc0d/itext/itext.kernel/itext/kernel/pdf/canvas/parser/listener/RegexBasedLocationExtractionStrategy.cs#L76

I also realized that regexes with newlines were not working, and it was because newlines were not being added to the text.