### PR TITLE
Fixes test cases failing with nonstandard minus sign

### DIFF
--- a/itext.tests/itext.svg.tests/itext/svg/converter/SvgConverterIntegrationTest.cs
+++ b/itext.tests/itext.svg.tests/itext/svg/converter/SvgConverterIntegrationTest.cs
@@ -197,7 +197,7 @@ namespace iText.Svg.Converter {
             String name = "eclipse";
             int x = -50;
             int y = 0;
-            String destName = name + "_" + x + "_" + y;
+            String destName = String.Format(System.Globalization.CultureInfo.InvariantCulture, "{0}_{1}_{2}", name, x, y);
             FileStream fis = new FileStream(sourceFolder + name + ".svg", FileMode.Open, FileAccess.Read);
             DrawOnSpecifiedPositionDocument(fis, destinationFolder + destName + ".pdf", x, y);
             NUnit.Framework.Assert.IsNull(new CompareTool().CompareVisually(destinationFolder + destName + ".pdf", sourceFolder
@@ -211,7 +211,7 @@ namespace iText.Svg.Converter {
             String name = "eclipse";
             int x = 0;
             int y = -100;
-            String destName = name + "_" + x + "_" + y;
+            String destName = String.Format(System.Globalization.CultureInfo.InvariantCulture, "{0}_{1}_{2}", name, x, y);
             FileStream fis = new FileStream(sourceFolder + name + ".svg", FileMode.Open, FileAccess.Read);
             DrawOnSpecifiedPositionDocument(fis, destinationFolder + destName + ".pdf", x, y);
             NUnit.Framework.Assert.IsNull(new CompareTool().CompareVisually(destinationFolder + destName + ".pdf", sourceFolder
@@ -225,7 +225,7 @@ namespace iText.Svg.Converter {
             String name = "eclipse";
             int x = -50;
             int y = -100;
-            String destName = name + "_" + x + "_" + y;
+            String destName = String.Format(System.Globalization.CultureInfo.InvariantCulture, "{0}_{1}_{2}", name, x, y);
             FileStream fis = new FileStream(sourceFolder + name + ".svg", FileMode.Open, FileAccess.Read);
             DrawOnSpecifiedPositionDocument(fis, destinationFolder + destName + ".pdf", x, y);
             NUnit.Framework.Assert.IsNull(new CompareTool().CompareVisually(destinationFolder + destName + ".pdf", sourceFolder
@@ -239,7 +239,7 @@ namespace iText.Svg.Converter {
             String name = "eclipse";
             int x = -50;
             int y = -50;
-            String destName = name + "_" + x + "_" + y;
+            String destName = String.Format(System.Globalization.CultureInfo.InvariantCulture, "{0}_{1}_{2}", name, x, y);
             FileStream fis = new FileStream(sourceFolder + name + ".svg", FileMode.Open, FileAccess.Read);
             DrawOnSpecifiedPositionDocument(fis, destinationFolder + destName + ".pdf", x, y);
             NUnit.Framework.Assert.IsNull(new CompareTool().CompareVisually(destinationFolder + destName + ".pdf", sourceFolder

--- a/itext/itext.io/itext/io/font/CidFont.cs
+++ b/itext/itext.io/itext/io/font/CidFont.cs
@@ -115,13 +115,13 @@ namespace iText.IO.Font {
             fontMetrics.SetItalicAngle(Convert.ToInt32((String)fontDesc.Get("ItalicAngle")));
             fontMetrics.SetCapHeight(Convert.ToInt32((String)fontDesc.Get("CapHeight")));
             fontMetrics.SetTypoAscender(Convert.ToInt32((String)fontDesc.Get("Ascent")));
-            fontMetrics.SetTypoDescender(Convert.ToInt32((String)fontDesc.Get("Descent")));
+            fontMetrics.SetTypoDescender(Convert.ToInt32((String)fontDesc.Get("Descent"), System.Globalization.CultureInfo.InvariantCulture));
             fontMetrics.SetStemV(Convert.ToInt32((String)fontDesc.Get("StemV")));
             pdfFontFlags = Convert.ToInt32((String)fontDesc.Get("Flags"));
             String fontBBox = (String)fontDesc.Get("FontBBox");
             StringTokenizer tk = new StringTokenizer(fontBBox, " []\r\n\t\f");
-            int llx = Convert.ToInt32(tk.NextToken());
-            int lly = Convert.ToInt32(tk.NextToken());
+            int llx = Convert.ToInt32(tk.NextToken(), System.Globalization.CultureInfo.InvariantCulture);
+            int lly = Convert.ToInt32(tk.NextToken(), System.Globalization.CultureInfo.InvariantCulture);
             int urx = Convert.ToInt32(tk.NextToken());
             int ury = Convert.ToInt32(tk.NextToken());
             fontMetrics.UpdateBbox(llx, lly, urx, ury);

--- a/itext/itext.io/itext/io/font/Pfm2afm.cs
+++ b/itext/itext.io/itext/io/font/Pfm2afm.cs
@@ -103,7 +103,7 @@ namespace iText.IO.Font {
 
         private void Outval(int n) {
             output.Write(' ');
-            output.Write(n);
+            output.Write(n.ToString(System.Globalization.CultureInfo.InvariantCulture));
         }
 
         /*

--- a/itext/itext.io/itext/io/font/Type1Font.cs
+++ b/itext/itext.io/itext/io/font/Type1Font.cs
@@ -393,7 +393,7 @@ namespace iText.IO.Font {
                     ident = tokc.NextToken();
                     switch (ident) {
                         case "C": {
-                            C = Convert.ToInt32(tokc.NextToken());
+                            C = Convert.ToInt32(tokc.NextToken(), System.Globalization.CultureInfo.InvariantCulture);
                             break;
                         }
 
@@ -408,8 +408,10 @@ namespace iText.IO.Font {
                         }
 
                         case "B": {
-                            B = new int[] { Convert.ToInt32(tokc.NextToken()), Convert.ToInt32(tokc.NextToken()), Convert.ToInt32(tokc
-                                .NextToken()), Convert.ToInt32(tokc.NextToken()) };
+                            B = new int[] { Convert.ToInt32(tokc.NextToken(), System.Globalization.CultureInfo.InvariantCulture),
+                                Convert.ToInt32(tokc.NextToken(), System.Globalization.CultureInfo.InvariantCulture),
+                                Convert.ToInt32(tokc.NextToken(), System.Globalization.CultureInfo.InvariantCulture),
+                                Convert.ToInt32(tokc.NextToken(), System.Globalization.CultureInfo.InvariantCulture) };
                             break;
                         }
                     }

--- a/itext/itext.styledxmlparser/itext/styledxmlparser/css/selector/item/CssPseudoClassNthSelectorItem.cs
+++ b/itext/itext.styledxmlparser/itext/styledxmlparser/css/selector/item/CssPseudoClassNthSelectorItem.cs
@@ -98,7 +98,7 @@ namespace iText.StyledXmlParser.Css.Selector.Item {
                             }
                             String bParticle = arguments.Substring(indexOfN + 1).Trim();
                             if (!String.IsNullOrEmpty(bParticle)) {
-                                this.nthB = Convert.ToInt32(bParticle[0] + bParticle.Substring(1).Trim());
+                                this.nthB = Convert.ToInt32(bParticle[0] + bParticle.Substring(1).Trim(), System.Globalization.CultureInfo.InvariantCulture);
                             }
                             else {
                                 this.nthB = 0;

--- a/itext/itext.styledxmlparser/itext/styledxmlparser/jsoup/select/QueryParser.cs
+++ b/itext/itext.styledxmlparser/itext/styledxmlparser/jsoup/select/QueryParser.cs
@@ -459,14 +459,14 @@ namespace iText.StyledXmlParser.Jsoup.Select {
                 else {
                     if (mAB.Success) {
                         a = iText.IO.Util.StringUtil.Group(mAB, 3) != null ? Convert.ToInt32(iText.IO.Util.StringUtil.Group(mAB, 1
-                            ).ReplaceFirst("^\\+", "")) : 1;
+                            ).ReplaceFirst("^\\+", ""), System.Globalization.CultureInfo.InvariantCulture) : 1;
                         b = iText.IO.Util.StringUtil.Group(mAB, 4) != null ? Convert.ToInt32(iText.IO.Util.StringUtil.Group(mAB, 4
-                            ).ReplaceFirst("^\\+", "")) : 0;
+                            ).ReplaceFirst("^\\+", ""), System.Globalization.CultureInfo.InvariantCulture) : 0;
                     }
                     else {
                         if (mB.Success) {
                             a = 0;
-                            b = Convert.ToInt32(iText.IO.Util.StringUtil.Group(mB).ReplaceFirst("^\\+", ""));
+                            b = Convert.ToInt32(iText.IO.Util.StringUtil.Group(mB).ReplaceFirst("^\\+", ""), System.Globalization.CultureInfo.InvariantCulture);
                         }
                         else {
                             throw new Selector.SelectorParseException("Could not parse nth-index " + PortUtil.EscapedSingleBracket + "{0}"


### PR DESCRIPTION
The negative symbol is nearly always '-'. When it is not set to this character, at least on Windows, some of the tests were failing. This fixes first the unit tests and implementation which were failing, then fixes the GhostScript tests which were failing, although only in setup.