### PR TITLE
Bugfixing verification of good OCSP response

### DIFF
--- a/itext/itext.sign/itext/signatures/OCSPVerifier.cs
+++ b/itext/itext.sign/itext/signatures/OCSPVerifier.cs
@@ -174,7 +174,7 @@ namespace iText.Signatures {
                 }
                 // check the status of the certificate
                 Object status = resp[i].GetCertStatus();
-                if (status == CertificateStatus.Good) {
+                if (status == null || status == CertificateStatus.Good) {
                     // check if the OCSP response was genuine
                     IsValidResponse(ocspResp, issuerCert, signDate);
                     return true;


### PR DESCRIPTION
There was a problem using `OCSPVerifier` class method `Verify(...)`
Good OCSP responses returned `false` verification results.

According to BouncyCastle [documentation](https://www.bouncycastle.org/docs/pkixdocs1.4/org/bouncycastle/cert/ocsp/SingleResp.html#getCertStatus()) - `getCertStatus` method returns null value if certificate status is good.

> public CertificateStatus getCertStatus()
Return the status object for the response - null indicates good.
