### PR TITLE
Add Suppot for .net 5 so we can remove Microsoft.Extensions.DependencyModel 1.1.0

### DIFF
--- a/itext.tests/itext.barcodes.tests/Properties/AssemblyInfo.cs
+++ b/itext.tests/itext.barcodes.tests/Properties/AssemblyInfo.cs
@@ -18,6 +18,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion("7.1.15.0")]
 [assembly: AssemblyInformationalVersion("7.1.15-SNAPSHOT")]
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
 [assembly: NUnit.Framework.Timeout(300000)]
 #endif

--- a/itext.tests/itext.barcodes.tests/itext.barcodes.tests.netstandard.csproj
+++ b/itext.tests/itext.barcodes.tests/itext.barcodes.tests.netstandard.csproj
@@ -1,15 +1,18 @@
-<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup Label="Configuration">
     <SignAssembly>True</SignAssembly>
     <DelaySign>False</DelaySign>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net40</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp2.0;net40</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' ">
     <OutputType>library</OutputType>
   </PropertyGroup>
+	<PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+		<OutputType>library</OutputType>
+	</PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <OutputType>Library</OutputType>
     <DefineConstants>NETSTANDARD2_0</DefineConstants>
@@ -45,12 +48,8 @@
   </ItemGroup>
   <ItemGroup>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <PackageReference Include="Microsoft.NET.Test.Sdk">
-      <Version>15.0.0</Version>
-    </PackageReference>
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation">
-      <Version>4.3.0</Version>
-    </PackageReference>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net40'">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+	<PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/itext.tests/itext.forms.tests/Properties/AssemblyInfo.cs
+++ b/itext.tests/itext.forms.tests/Properties/AssemblyInfo.cs
@@ -18,6 +18,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion("7.1.15.0")]
 [assembly: AssemblyInformationalVersion("7.1.15-SNAPSHOT")]
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
 [assembly: NUnit.Framework.Timeout(300000)]
 #endif

--- a/itext.tests/itext.forms.tests/itext.forms.tests.netstandard.csproj
+++ b/itext.tests/itext.forms.tests/itext.forms.tests.netstandard.csproj
@@ -5,11 +5,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net40</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp2.0;net40</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' ">
     <OutputType>library</OutputType>
   </PropertyGroup>
+	<PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+		<OutputType>library</OutputType>
+	</PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <OutputType>Library</OutputType>
     <DefineConstants>NETSTANDARD2_0</DefineConstants>
@@ -49,12 +52,8 @@
   </ItemGroup>
   <ItemGroup>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <PackageReference Include="Microsoft.NET.Test.Sdk">
-      <Version>15.0.0</Version>
-    </PackageReference>
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation">
-      <Version>4.3.0</Version>
-    </PackageReference>
-  </ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' != 'net40'">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+		<PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+	</ItemGroup>
 </Project>

--- a/itext.tests/itext.forms.tests/itext/forms/FlatteningWithNullKidElementTest.cs
+++ b/itext.tests/itext.forms.tests/itext/forms/FlatteningWithNullKidElementTest.cs
@@ -16,7 +16,7 @@ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
 or FITNESS FOR A PARTICULAR PURPOSE.
 See the GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
-along with this program; if not, see http://www.gnu.org/licenses or write to
+along with this program; if not, see http://www.gnu.org/licenses or write tod
 the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
 Boston, MA, 02110-1301 USA, or download the license from the following URL:
 http://itextpdf.com/terms-of-use/

--- a/itext.tests/itext.forms.tests/itext/forms/xfa/XXEVulnerabilityTest.cs
+++ b/itext.tests/itext.forms.tests/itext/forms/xfa/XXEVulnerabilityTest.cs
@@ -66,7 +66,7 @@ namespace iText.Forms.Xfa {
             String outFileName = destinationFolder + "outXfaExternalFile.pdf";
             String cmpFileName = sourceFolder + "cmp_outXfaExternalFile.pdf";
             
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET5_0
             using (PdfDocument pdfDoc = new PdfDocument(new PdfReader(inFileName), new PdfWriter(outFileName).SetCompressionLevel
                 (CompressionConstants.NO_COMPRESSION))) {
                 NUnit.Framework.Assert.That(() =>
@@ -98,7 +98,7 @@ namespace iText.Forms.Xfa {
             String outFileName = destinationFolder + "outXfaExternalConnection.pdf";
             String cmpFileName = sourceFolder + "cmp_outXfaExternalConnection.pdf";
             
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET5_0
             using (PdfDocument pdfDoc = new PdfDocument(new PdfReader(inFileName), new PdfWriter(outFileName).SetCompressionLevel
                 (CompressionConstants.NO_COMPRESSION))) {
                 NUnit.Framework.Assert.That(() =>

--- a/itext.tests/itext.io.tests/Properties/AssemblyInfo.cs
+++ b/itext.tests/itext.io.tests/Properties/AssemblyInfo.cs
@@ -19,6 +19,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion("7.1.15.0")]
 [assembly: AssemblyInformationalVersion("7.1.15-SNAPSHOT")]
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
 [assembly: NUnit.Framework.Timeout(300000)]
 #endif

--- a/itext.tests/itext.io.tests/itext.io.tests.netstandard.csproj
+++ b/itext.tests/itext.io.tests/itext.io.tests.netstandard.csproj
@@ -5,7 +5,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net40</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp2.0;net40</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' ">
     <OutputType>library</OutputType>
@@ -52,6 +52,14 @@
       <Version>4.3.0</Version>
     </PackageReference>
   </ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+		<PackageReference Include="Microsoft.NET.Test.Sdk">
+			<Version>15.0.0</Version>
+		</PackageReference>
+		<PackageReference Include="System.Runtime.InteropServices.RuntimeInformation">
+			<Version>4.3.0</Version>
+		</PackageReference>
+	</ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/itext.tests/itext.kernel.tests/Properties/AssemblyInfo.cs
+++ b/itext.tests/itext.kernel.tests/Properties/AssemblyInfo.cs
@@ -19,6 +19,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion("7.1.15.0")]
 [assembly: AssemblyInformationalVersion("7.1.15-SNAPSHOT")]
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
 [assembly: NUnit.Framework.Timeout(300000)]
 #endif

--- a/itext.tests/itext.kernel.tests/itext.kernel.tests.netstandard.csproj
+++ b/itext.tests/itext.kernel.tests/itext.kernel.tests.netstandard.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup Label="Configuration">
     <SignAssembly>True</SignAssembly>
     <DelaySign>False</DelaySign>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net40</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp2.0;net40</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' ">
     <OutputType>library</OutputType>

--- a/itext.tests/itext.kernel.tests/itext/kernel/pdf/PdfReaderTest.cs
+++ b/itext.tests/itext.kernel.tests/itext/kernel/pdf/PdfReaderTest.cs
@@ -1193,7 +1193,7 @@ namespace iText.Kernel.Pdf {
             document.Close();
         }
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0 && !NET5_0
         [NUnit.Framework.Timeout(1000)]
 #endif // !NETSTANDARD2_0
         [NUnit.Framework.Test]
@@ -1213,7 +1213,7 @@ namespace iText.Kernel.Pdf {
             }
         }
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
         [NUnit.Framework.Timeout(1000)]
 #endif // !NETSTANDARD2_0
         [NUnit.Framework.Test]
@@ -1230,7 +1230,7 @@ namespace iText.Kernel.Pdf {
             }
         }
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
         [NUnit.Framework.Timeout(1000)]
 #endif // !NETSTANDARD2_0
         [NUnit.Framework.Test]
@@ -1247,7 +1247,7 @@ namespace iText.Kernel.Pdf {
             }
         }
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
         [NUnit.Framework.Timeout(1000)]
 #endif // !NETSTANDARD2_0
         [NUnit.Framework.Test]
@@ -1264,7 +1264,7 @@ namespace iText.Kernel.Pdf {
             }
         }
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
         [NUnit.Framework.Timeout(1000)]
 #endif // !NETSTANDARD2_0
         [NUnit.Framework.Test]
@@ -1281,7 +1281,7 @@ namespace iText.Kernel.Pdf {
             }
         }
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
         [NUnit.Framework.Timeout(1000)]
 #endif // !NETSTANDARD2_0
         [NUnit.Framework.Test]
@@ -1298,7 +1298,7 @@ namespace iText.Kernel.Pdf {
             }
         }
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
         [NUnit.Framework.Timeout(1000)]
 #endif // !NETSTANDARD2_0
         [NUnit.Framework.Test]
@@ -1315,7 +1315,7 @@ namespace iText.Kernel.Pdf {
             }
         }
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
         [NUnit.Framework.Timeout(1000)]
 #endif // !NETSTANDARD2_0
         [NUnit.Framework.Test]
@@ -1332,7 +1332,7 @@ namespace iText.Kernel.Pdf {
             }
         }
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
         [NUnit.Framework.Timeout(1000)]
 #endif // !NETSTANDARD2_0
         [NUnit.Framework.Test]

--- a/itext.tests/itext.kernel.tests/itext/kernel/pdf/xobject/ImageFromLanguageStandardLibraryTest.cs
+++ b/itext.tests/itext.kernel.tests/itext/kernel/pdf/xobject/ImageFromLanguageStandardLibraryTest.cs
@@ -42,7 +42,7 @@ address: sales@itextpdf.com
 */
 
 // System.Drawing doesn't exist within .netcoreapp
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
 
 using iText.Kernel.Font;
 using iText.Kernel.Pdf.Canvas;

--- a/itext.tests/itext.kernel.tests/itext/kernel/xmp/impl/XMPMetaParserTest.cs
+++ b/itext.tests/itext.kernel.tests/itext/kernel/xmp/impl/XMPMetaParserTest.cs
@@ -53,7 +53,7 @@ namespace iText.Kernel.XMP.Impl {
              + "                                                                                                    \n"
              + "             \n" + "<?xpacket end=\"w\"?>";
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
         [NUnit.Framework.Test]
         public virtual void XxeTestFromString() {
             String metadataToParse = MessageFormatUtil.Format(XMP_WITH_XXE, XXE_FILE_PATH);
@@ -76,7 +76,7 @@ namespace iText.Kernel.XMP.Impl {
         }
 #endif // NETSTANDARD2_0
         
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
         [NUnit.Framework.Test]
         public virtual void XxeTestFromByteBuffer() {
             String metadataToParse = MessageFormatUtil.Format(XMP_WITH_XXE, XXE_FILE_PATH);
@@ -99,7 +99,7 @@ namespace iText.Kernel.XMP.Impl {
         }
 #endif // NETSTANDARD2_0
         
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
         [NUnit.Framework.Test]
         public virtual void XxeTestFromInputStream() {
             String metadataToParse = MessageFormatUtil.Format(XMP_WITH_XXE, XXE_FILE_PATH);

--- a/itext/itext.barcodes/itext.barcodes.netstandard.csproj
+++ b/itext/itext.barcodes/itext.barcodes.netstandard.csproj
@@ -6,7 +6,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
+    <TargetFrameworks>net5.0;netstandard2.0;net40</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <OutputType>library</OutputType>

--- a/itext/itext.barcodes/itext/barcodes/BarcodesExtensions.cs
+++ b/itext/itext.barcodes/itext/barcodes/BarcodesExtensions.cs
@@ -84,7 +84,7 @@ namespace iText.Barcodes {
         }
 
         public static Assembly GetAssembly(this Type type) {
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
             return type.Assembly;
 #else
             return type.GetTypeInfo().Assembly;

--- a/itext/itext.font-asian/itext.font-asian.netstandard.csproj
+++ b/itext/itext.font-asian/itext.font-asian.netstandard.csproj
@@ -8,7 +8,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
+    <TargetFrameworks>net5.0;netstandard2.0;net40</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <OutputType>library</OutputType>

--- a/itext/itext.forms/itext.forms.netstandard.csproj
+++ b/itext/itext.forms/itext.forms.netstandard.csproj
@@ -6,7 +6,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
+    <TargetFrameworks>net5.0;netstandard2.0;net40</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <OutputType>library</OutputType>

--- a/itext/itext.forms/itext/forms/FormsExtensions.cs
+++ b/itext/itext.forms/itext/forms/FormsExtensions.cs
@@ -128,7 +128,7 @@ namespace iText.Forms {
 
         public static Assembly GetAssembly(this Type type)
         {
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
             return type.Assembly;
 #else
             return type.GetTypeInfo().Assembly;

--- a/itext/itext.hyph/itext.hyph.netstandard.csproj
+++ b/itext/itext.hyph/itext.hyph.netstandard.csproj
@@ -7,7 +7,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
+    <TargetFrameworks>net5.0;netstandard2.0;net40</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <OutputType>library</OutputType>

--- a/itext/itext.io/Properties/AssemblyInfo.cs
+++ b/itext/itext.io/Properties/AssemblyInfo.cs
@@ -35,6 +35,6 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("39631ecb-1d39-4eb2-b775-37bd34cbf5a4")]
 
-[assembly: AssemblyVersion("7.1.15.0")]
-[assembly: AssemblyFileVersion("7.1.15.0")]
-[assembly: AssemblyInformationalVersion("7.1.15-SNAPSHOT")]
+[assembly: AssemblyVersion("7.2.0.0")]
+[assembly: AssemblyFileVersion("7.2.0.0")]
+[assembly: AssemblyInformationalVersion("7.2.0-SNAPSHOT")]

--- a/itext/itext.io/itext.io.netstandard.csproj
+++ b/itext/itext.io/itext.io.netstandard.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup Label="Configuration">
     <SignAssembly>True</SignAssembly>
     <DelaySign>False</DelaySign>
@@ -6,7 +6,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
+    <TargetFrameworks>net5.0;netstandard2.0;net40</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <OutputType>library</OutputType>
@@ -81,9 +81,16 @@
     <PackageReference Include="System.Globalization.Extensions" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.9" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
   </ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+		<PackageReference Include="System.Globalization.Extensions" Version="4.3.0" />
+		<PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
+		<PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="5.0.0" />
+		<PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
+	</ItemGroup>
   <ItemGroup>
     <PackageReference Include="Common.Logging" Version="3.4.1" />
   </ItemGroup>

--- a/itext/itext.io/itext.io.netstandard.csproj
+++ b/itext/itext.io/itext.io.netstandard.csproj
@@ -85,11 +85,7 @@
     <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
   </ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-		<PackageReference Include="System.Globalization.Extensions" Version="4.3.0" />
-		<PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
-		<PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="5.0.0" />
-		<PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
 	</ItemGroup>
   <ItemGroup>
     <PackageReference Include="Common.Logging" Version="3.4.1" />

--- a/itext/itext.io/itext/io/IOExtensions.cs
+++ b/itext/itext.io/itext/io/IOExtensions.cs
@@ -197,7 +197,7 @@ namespace iText.IO {
         }
 
         public static Assembly GetAssembly(this Type type) {
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
             return type.Assembly;
 #else
             return type.GetTypeInfo().Assembly;

--- a/itext/itext.io/itext/io/image/DrawingImageFactory.cs
+++ b/itext/itext.io/itext/io/image/DrawingImageFactory.cs
@@ -1,4 +1,4 @@
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
 /*
 
 This file is part of the iText (R) project.

--- a/itext/itext.io/itext/io/image/ImageDataFactory.cs
+++ b/itext/itext.io/itext/io/image/ImageDataFactory.cs
@@ -164,7 +164,7 @@ namespace iText.IO.Image {
             return image;
         }
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
         /// <summary>Gets an instance of an Image from a java.awt.Image</summary>
         /// <param name="image">the java.awt.Image to convert</param>
         /// <param name="color">if different from <c>null</c> the transparency pixels are replaced by this color</param>
@@ -174,7 +174,7 @@ namespace iText.IO.Image {
         }
 #endif // !NETSTANDARD2_0
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
         /// <summary>Gets an instance of an Image from a java.awt.Image.</summary>
         /// <param name="image">the <c>java.awt.Image</c> to convert</param>
         /// <param name="color">if different from <c>null</c> the transparency pixels are replaced by this color</param>

--- a/itext/itext.io/itext/io/util/AssemblyLoadContextUtil.cs
+++ b/itext/itext.io/itext/io/util/AssemblyLoadContextUtil.cs
@@ -48,7 +48,7 @@ using System.Text;
 
 namespace iText.IO.Util
 {
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET5_0
     /// <summary>This file is a helper class for internal usage only.</summary>
     /// <remarks>
     /// This file is a helper class for internal usage only.

--- a/itext/itext.io/itext/io/util/EncodingUtil.cs
+++ b/itext/itext.io/itext/io/util/EncodingUtil.cs
@@ -54,7 +54,7 @@ namespace iText.IO.Util {
     public static class EncodingUtil {
 
         static EncodingUtil() {
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET5_0
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 #endif
         }

--- a/itext/itext.io/itext/io/util/IntHashtable.cs
+++ b/itext/itext.io/itext/io/util/IntHashtable.cs
@@ -58,7 +58,7 @@ namespace iText.IO.Util {
     /// <author>Bruno Lowagie (change Objects as keys into int values)</author>
     /// <author>Paulo Soares (added extra methods)</author>
     public class IntHashtable
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
  : ICloneable
 #endif
  {

--- a/itext/itext.io/itext/io/util/ResourceUtil.cs
+++ b/itext/itext.io/itext/io/util/ResourceUtil.cs
@@ -47,6 +47,10 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+#if NET5_0
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.DependencyModel;
+#endif
 #if NETSTANDARD2_0
 using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.Extensions.DependencyModel;
@@ -123,7 +127,7 @@ namespace iText.IO.Util {
                 }
             }
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
             foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies()) {
                 if (assembly.GetName().Name.StartsWith("itext")) {
                     istr = SearchResourceInAssembly(key, assembly);
@@ -135,7 +139,12 @@ namespace iText.IO.Util {
 #else
             try {
                 if (DependencyContext.Default != null) {
-                    string runtimeId = RuntimeEnvironment.GetRuntimeIdentifier();
+                    string runtimeId = "";
+#if NET5_0
+                    runtimeId = RuntimeInformation.RuntimeIdentifier;
+#else
+                    runtimeId = RuntimeEnvironment.GetRuntimeIdentifier();
+#endif
                     IEnumerable<AssemblyName> loadedAssemblies = DependencyContext.Default.GetRuntimeAssemblyNames(runtimeId).ToList();
                     foreach (AssemblyName assemblyName in loadedAssemblies) {
                         if (assemblyName.Name.StartsWith("itext")) {
@@ -151,7 +160,6 @@ namespace iText.IO.Util {
                 }
             } catch { }
 #endif
-
             return istr;
         }
 
@@ -170,7 +178,7 @@ namespace iText.IO.Util {
                     string dir = (string)obj;
                     try
                     {
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
                         istr = Assembly.LoadFrom(dir).GetManifestResourceStream(key);
 #else
                         istr = AssemblyLoadContextUtil.LoadFromDefaultContextAssemblyPath(key).GetManifestResourceStream(key);
@@ -204,7 +212,7 @@ namespace iText.IO.Util {
         }
 
         private static void LoadITextResourceAssemblies() {
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
             var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies().Where( a=> !a.IsDynamic).ToList();
             List<string> loadedPaths = new List<string>();
             foreach (var a in AppDomain.CurrentDomain.GetAssemblies())
@@ -236,7 +244,12 @@ namespace iText.IO.Util {
                 }
             }
 #else
-            string runtimeId = RuntimeEnvironment.GetRuntimeIdentifier();
+            string runtimeId = "";
+#if NET5_0
+            runtimeId = RuntimeInformation.RuntimeIdentifier;
+#else
+            runtimeId = RuntimeEnvironment.GetRuntimeIdentifier();
+#endif
             List<AssemblyName> loadedAssemblies = null;
             try {
                 loadedAssemblies = DependencyContext.Default?.GetRuntimeAssemblyNames(runtimeId).ToList();

--- a/itext/itext.kernel/KernelExtensions.cs
+++ b/itext/itext.kernel/KernelExtensions.cs
@@ -388,7 +388,7 @@ internal static class KernelExtensions {
         dgst.DoFinal(buff, offest);
     }
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
     public static Attribute GetCustomAttribute(this Assembly assembly, Type attributeType) {
         object[] customAttributes = assembly.GetCustomAttributes(attributeType, false);
         if (customAttributes.Length > 0 && customAttributes[0] is Attribute) {
@@ -400,14 +400,14 @@ internal static class KernelExtensions {
 #endif
 
     public static Assembly GetAssembly(this Type type) {
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
         return type.Assembly;
 #else
         return type.GetTypeInfo().Assembly;
 #endif
     }
 
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET5_0
     public static MethodInfo GetMethod(this Type type, String methodName, Type[] parameterTypes) {
         return type.GetTypeInfo().GetMethod(methodName, parameterTypes);
     }

--- a/itext/itext.kernel/itext.kernel.netstandard.csproj
+++ b/itext/itext.kernel/itext.kernel.netstandard.csproj
@@ -9,7 +9,7 @@
     <DefineConstants>PORTABLE;NEW_REFLECTION</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
+    <TargetFrameworks>net5.0;netstandard2.0;net40</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <OutputType>library</OutputType>

--- a/itext/itext.kernel/itext/kernel/geom/Point.cs
+++ b/itext/itext.kernel/itext/kernel/geom/Point.cs
@@ -98,7 +98,7 @@ namespace iText.Kernel.Geom {
         }
 
         public override int GetHashCode() {
-            HashCode hash = new HashCode();
+            iText.IO.Util.HashCode hash = new iText.IO.Util.HashCode();
             hash.Append(GetX());
             hash.Append(GetY());
             return hash.GetHashCode();

--- a/itext/itext.kernel/itext/kernel/xmp/XMPMeta.cs
+++ b/itext/itext.kernel/itext/kernel/xmp/XMPMeta.cs
@@ -40,7 +40,7 @@ namespace iText.Kernel.XMP {
     /// </remarks>
     /// <since>20.01.2006</since>
     public interface XMPMeta
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
  : ICloneable
 #endif
  {

--- a/itext/itext.layout/itext.layout.netstandard.csproj
+++ b/itext/itext.layout/itext.layout.netstandard.csproj
@@ -6,7 +6,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
+    <TargetFrameworks>net5.0;netstandard2.0;net40</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <OutputType>library</OutputType>

--- a/itext/itext.layout/itext/layout/LayoutExtensions.cs
+++ b/itext/itext.layout/itext/layout/LayoutExtensions.cs
@@ -229,14 +229,14 @@ namespace iText.Layout {
         }
 
         public static Assembly GetAssembly(this Type type) {
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
             return type.Assembly;
 #else
             return type.GetTypeInfo().Assembly;
 #endif
         }
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
         public static Attribute GetCustomAttribute(this Assembly assembly, Type attributeType) {
             object[] customAttributes = assembly.GetCustomAttributes(attributeType, false);
             if (customAttributes.Length > 0 && customAttributes[0] is Attribute) {
@@ -247,7 +247,7 @@ namespace iText.Layout {
         }
 #endif
 
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET5_0
         public static MethodInfo GetMethod(this Type type, String methodName, Type[] parameterTypes) {
             return type    .GetTypeInfo().GetMethod(methodName, parameterTypes);
         }

--- a/itext/itext.layout/itext/layout/layout/LayoutArea.cs
+++ b/itext/itext.layout/itext/layout/layout/LayoutArea.cs
@@ -116,7 +116,7 @@ namespace iText.Layout.Layout {
 
         /// <summary><inheritDoc/></summary>
         public override int GetHashCode() {
-            HashCode hashCode = new HashCode();
+            iText.IO.Util.HashCode hashCode = new iText.IO.Util.HashCode();
             hashCode.Append(pageNumber).Append(bBox.GetHashCode());
             return hashCode.GetHashCode();
         }

--- a/itext/itext.pdfa/itext.pdfa.netstandard.csproj
+++ b/itext/itext.pdfa/itext.pdfa.netstandard.csproj
@@ -6,7 +6,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
+    <TargetFrameworks>net5.0;netstandard2.0;net40</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <OutputType>library</OutputType>

--- a/itext/itext.pdfa/itext/pdfa/PdfAExtensions.cs
+++ b/itext/itext.pdfa/itext/pdfa/PdfAExtensions.cs
@@ -87,7 +87,7 @@ namespace iText.Pdfa {
         }
 
         public static Assembly GetAssembly(this Type type) {
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
             return type.Assembly;
 #else
             return type.GetTypeInfo().Assembly;

--- a/itext/itext.pdftest/itext.pdftest.netstandard.csproj
+++ b/itext/itext.pdftest/itext.pdftest.netstandard.csproj
@@ -6,7 +6,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
+    <TargetFrameworks>net5.0;netstandard2.0;net40</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <OutputType>library</OutputType>

--- a/itext/itext.pdftest/itext/test/PdfTestExtensions.cs
+++ b/itext/itext.pdftest/itext/test/PdfTestExtensions.cs
@@ -47,7 +47,7 @@ using System.Reflection;
 namespace iText.Test {
     internal static class PdfTestExtensions {
         public static Attribute GetCustomAttribute(this Type classType, Type attributeType) {
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
             return Attribute.GetCustomAttribute(classType, attributeType);
 #else
             return classType.GetTypeInfo().GetCustomAttribute(attributeType);
@@ -55,14 +55,14 @@ namespace iText.Test {
         }
 
         public static Assembly GetAssembly(this Type type) {
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
             return type.Assembly;
 #else
             return type.GetTypeInfo().Assembly;
 #endif
         }
 
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET5_0
         public static object[] GetCustomAttributes(this Type type, Type attributeType, bool inherit) {
             return type.GetTypeInfo().GetCustomAttributes(attributeType, inherit).ToArray();
         }

--- a/itext/itext.sign/itext.sign.netstandard.csproj
+++ b/itext/itext.sign/itext.sign.netstandard.csproj
@@ -6,7 +6,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
+    <TargetFrameworks>net5.0;netstandard2.0;net40</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <OutputType>library</OutputType>

--- a/itext/itext.sign/itext/signatures/AsymmetricAlgorithmSignature.cs
+++ b/itext/itext.sign/itext/signatures/AsymmetricAlgorithmSignature.cs
@@ -105,7 +105,7 @@ namespace iText.Signatures {
             : this((AsymmetricAlgorithm) algorithm, hashAlgorithm) {
         }
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
         public AsymmetricAlgorithmSignature(DSACryptoServiceProvider algorithm)
             : this((AsymmetricAlgorithm) algorithm, null) {
         }
@@ -117,7 +117,7 @@ namespace iText.Signatures {
 
             if (algorithm is RSACryptoServiceProvider)
                 encryptionAlgorithm = "RSA";
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
             else if (algorithm is DSACryptoServiceProvider)
                 encryptionAlgorithm = "DSA";
 #endif
@@ -130,14 +130,15 @@ namespace iText.Signatures {
                 RSACryptoServiceProvider rsa = (RSACryptoServiceProvider) algorithm;
                 return rsa.SignData(message, hashAlgorithm);
             }
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
             else
             {
             DSACryptoServiceProvider dsa = (DSACryptoServiceProvider) algorithm;
                 return dsa.SignData(message);
             }
 #else
-            else {
+            else
+            {
                 throw new ArgumentException("Not supported encryption algorithm " + algorithm);
             }
 #endif

--- a/itext/itext.styledxmlparser/StyledXmlParserExtensions.cs
+++ b/itext/itext.styledxmlparser/StyledXmlParserExtensions.cs
@@ -454,7 +454,7 @@ internal static class StyledXmlParserExtensions {
         return sb;
     }
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
     public static Attribute GetCustomAttribute(this Assembly assembly, Type attributeType)
     {
         object[] customAttributes = Assembly.GetExecutingAssembly().GetCustomAttributes(attributeType, false);
@@ -471,14 +471,14 @@ internal static class StyledXmlParserExtensions {
 
     public static Assembly GetAssembly(this Type type)
     {
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
         return type.Assembly;
 #else
         return type.GetTypeInfo().Assembly;
 #endif
     }
 
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET5_0
     public static MethodInfo GetMethod(this Type type, String methodName, Type[] parameterTypes) {
         return type.GetTypeInfo().GetMethod(methodName, parameterTypes);
     }

--- a/itext/itext.styledxmlparser/itext.styledxmlparser.netstandard.csproj
+++ b/itext/itext.styledxmlparser/itext.styledxmlparser.netstandard.csproj
@@ -6,7 +6,7 @@
     <DocumentationFile>$(TargetDir)bin\$(Configuration)\$(TargetFramework)\itext.styledxmlparser.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
+    <TargetFrameworks>net5.0;netstandard2.0;net40</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <OutputType>library</OutputType>

--- a/itext/itext.styledxmlparser/itext/styledxmlparser/css/CssFontFaceRule.cs
+++ b/itext/itext.styledxmlparser/itext/styledxmlparser/css/CssFontFaceRule.cs
@@ -92,8 +92,8 @@ namespace iText.StyledXmlParser.Css {
             return sb.ToString();
         }
 
-        public virtual Range ResolveUnicodeRange() {
-            Range range = null;
+        public virtual iText.Layout.Font.Range ResolveUnicodeRange() {
+            iText.Layout.Font.Range range = null;
             foreach (CssDeclaration descriptor in GetProperties()) {
                 if ("unicode-range".Equals(descriptor.GetProperty())) {
                     range = CssUtils.ParseUnicodeRange(descriptor.GetExpression());

--- a/itext/itext.styledxmlparser/itext/styledxmlparser/css/util/CssUtils.cs
+++ b/itext/itext.styledxmlparser/itext/styledxmlparser/css/util/CssUtils.cs
@@ -715,7 +715,7 @@ namespace iText.StyledXmlParser.Css.Util {
         /// <see cref="iText.Layout.Font.Range"/>
         /// object
         /// </returns>
-        public static Range ParseUnicodeRange(String unicodeRange) {
+        public static iText.Layout.Font.Range ParseUnicodeRange(String unicodeRange) {
             String[] ranges = iText.IO.Util.StringUtil.Split(unicodeRange, ",");
             RangeBuilder builder = new RangeBuilder();
             foreach (String range in ranges) {

--- a/itext/itext.styledxmlparser/itext/styledxmlparser/jsoup/nodes/Document.cs
+++ b/itext/itext.styledxmlparser/itext/styledxmlparser/jsoup/nodes/Document.cs
@@ -479,10 +479,10 @@ namespace iText.StyledXmlParser.Jsoup.Nodes {
 
     /// <summary>A Document's output settings control the form of the text() and html() methods.</summary>
     public class OutputSettings
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
  : ICloneable
 #endif
- {
+    {
         private Entities.EscapeMode escapeMode = Entities.EscapeMode.@base;
 
         private System.Text.Encoding charset = EncodingUtil.GetEncoding("UTF-8");

--- a/itext/itext.styledxmlparser/itext/styledxmlparser/jsoup/nodes/Node.cs
+++ b/itext/itext.styledxmlparser/itext/styledxmlparser/jsoup/nodes/Node.cs
@@ -53,10 +53,10 @@ namespace iText.StyledXmlParser.Jsoup.Nodes {
     /// <remarks>The base, abstract Node model. Elements, Documents, Comments etc are all Node instances.</remarks>
     /// <author>Jonathan Hedley, jonathan@hedley.net</author>
     public abstract class Node
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
  : ICloneable
 #endif
- {
+    {
         private static readonly IList<iText.StyledXmlParser.Jsoup.Nodes.Node> EMPTY_NODES = JavaCollectionsUtil.EmptyList
             <iText.StyledXmlParser.Jsoup.Nodes.Node>();
 

--- a/itext/itext.svg/SvgExtensions.cs
+++ b/itext/itext.svg/SvgExtensions.cs
@@ -406,7 +406,7 @@ internal static class SvgExtensions {
         return sb;
     }
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
     public static Attribute GetCustomAttribute(this Assembly assembly, Type attributeType)
     {
         object[] customAttributes = Assembly.GetExecutingAssembly().GetCustomAttributes(attributeType, false);
@@ -423,14 +423,14 @@ internal static class SvgExtensions {
 
     public static Assembly GetAssembly(this Type type)
     {
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET5_0
         return type.Assembly;
 #else
         return type.GetTypeInfo().Assembly;
 #endif
     }
 
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET5_0
     public static MethodInfo GetMethod(this Type type, String methodName, Type[] parameterTypes) {
         return type.GetTypeInfo().GetMethod(methodName, parameterTypes);
     }

--- a/itext/itext.svg/itext.svg.netstandard.csproj
+++ b/itext/itext.svg/itext.svg.netstandard.csproj
@@ -6,7 +6,7 @@
     <DocumentationFile>$(TargetDir)bin\$(Configuration)\$(TargetFramework)\itext.svg.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
+    <TargetFrameworks>net5.0;netstandard2.0;net40</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <OutputType>library</OutputType>

--- a/itext/itext.svg/itext/svg/processors/impl/SvgProcessorContext.cs
+++ b/itext/itext.svg/itext/svg/processors/impl/SvgProcessorContext.cs
@@ -130,7 +130,7 @@ namespace iText.Svg.Processors.Impl {
         /// <param name="encoding">the encoding</param>
         /// <param name="alias">the alias</param>
         /// <param name="unicodeRange">the specific range of characters to be used from the font</param>
-        public virtual void AddTemporaryFont(FontProgram fontProgram, String encoding, String alias, Range unicodeRange
+        public virtual void AddTemporaryFont(FontProgram fontProgram, String encoding, String alias, iText.Layout.Font.Range unicodeRange
             ) {
             if (tempFonts == null) {
                 tempFonts = new FontSet();

--- a/itext/itext.svg/itext/svg/processors/impl/font/SvgFontProcessor.cs
+++ b/itext/itext.svg/itext/svg/processors/impl/font/SvgFontProcessor.cs
@@ -87,7 +87,7 @@ namespace iText.Svg.Processors.Impl.Font {
         /// <param name="fontFamily">the font family</param>
         /// <param name="src">the source of the font</param>
         /// <returns>true, if successful</returns>
-        private bool CreateFont(String fontFamily, CssFontFace.CssFontFaceSrc src, Range unicodeRange) {
+        private bool CreateFont(String fontFamily, CssFontFace.CssFontFaceSrc src, iText.Layout.Font.Range unicodeRange) {
             if (!CssFontFace.IsSupportedFontFormat(src.GetFormat())) {
                 return false;
             }

--- a/itext7.nuspec
+++ b/itext7.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>itext7</id>
-    <version>7.1.15-SNAPSHOT</version>
+    <version>7.2.0-SNAPSHOT</version>
     <title>iText 7 Community</title>
     <authors>iText Software</authors>
     <owners>iText Software</owners>
@@ -36,6 +36,11 @@
         <dependency id="System.Threading.ThreadPool" version="4.3.0" />
         <dependency id="System.Xml.XmlDocument" version="4.3.0" />
         <dependency id="System.Security.Cryptography.Csp" version="4.3.0" />
+      </group>
+      <group targetFramework="net5.0">
+        <dependency id="Common.Logging" version="3.4.1" />
+        <dependency id="Portable.BouncyCastle" version="1.8.9" />
+		<dependency id="Microsoft.Extensions.DependencyModel" version="5.0.0" />
       </group>
     </dependencies>
   </metadata>
@@ -76,6 +81,24 @@
     <file src="itext\itext.styledxmlparser\bin\Release\netstandard2.0\itext.styledxmlparser.xml" target="lib\netstandard2.0" />
     <file src="itext\itext.svg\bin\Release\netstandard2.0\itext.svg.dll" target="lib\netstandard2.0" />
     <file src="itext\itext.svg\bin\Release\netstandard2.0\itext.svg.xml" target="lib\netstandard2.0" />
+    <file src="itext\itext.io\bin\Release\net5.0\itext.io.dll" target="lib\net5.0" />
+    <file src="itext\itext.io\bin\Release\net5.0\itext.io.xml" target="lib\net5.0" />
+    <file src="itext\itext.kernel\bin\Release\net5.0\itext.kernel.dll" target="lib\net5.0" />
+    <file src="itext\itext.kernel\bin\Release\net5.0\itext.kernel.xml" target="lib\net5.0" />
+    <file src="itext\itext.layout\bin\Release\net5.0\itext.layout.dll" target="lib\net5.0" />
+    <file src="itext\itext.layout\bin\Release\net5.0\itext.layout.xml" target="lib\net5.0" />
+    <file src="itext\itext.pdfa\bin\Release\net5.0\itext.pdfa.dll" target="lib\net5.0" />
+    <file src="itext\itext.pdfa\bin\Release\net5.0\itext.pdfa.xml" target="lib\net5.0" />
+    <file src="itext\itext.forms\bin\Release\net5.0\itext.forms.dll" target="lib\net5.0" />
+    <file src="itext\itext.forms\bin\Release\net5.0\itext.forms.xml" target="lib\net5.0" />
+    <file src="itext\itext.barcodes\bin\Release\net5.0\itext.barcodes.dll" target="lib\net5.0" />
+    <file src="itext\itext.barcodes\bin\Release\net5.0\itext.barcodes.xml" target="lib\net5.0" />
+    <file src="itext\itext.sign\bin\Release\net5.0\itext.sign.dll" target="lib\net5.0" />
+    <file src="itext\itext.sign\bin\Release\net5.0\itext.sign.xml" target="lib\net5.0" />
+    <file src="itext\itext.styledxmlparser\bin\Release\net5.0\itext.styledxmlparser.dll" target="lib\net5.0" />
+    <file src="itext\itext.styledxmlparser\bin\Release\net5.0\itext.styledxmlparser.xml" target="lib\net5.0" />
+    <file src="itext\itext.svg\bin\Release\net5.0\itext.svg.dll" target="lib\net5.0" />
+    <file src="itext\itext.svg\bin\Release\net5.0\itext.svg.xml" target="lib\net5.0" />
     <file src="gnu-agpl-v3.0.md" target="" />
     <file src="LICENSE.md" target="" />
 	<file src="ITSC-avatar.png" target="" />


### PR DESCRIPTION
We had issues in a project running in net 5 with Microsoft.Extensions.DependencyModel 1.1.0.
