### PR TITLE
Fixed casting exception in XfaForm.GetNodeText()

### DIFF
--- a/itext.tests/itext.forms.tests/itext/forms/xfa/XFAFormTest.cs
+++ b/itext.tests/itext.forms.tests/itext/forms/xfa/XFAFormTest.cs
@@ -141,5 +141,15 @@ namespace iText.Forms.Xfa {
             NUnit.Framework.Assert.IsNotNull(node);
             NUnit.Framework.Assert.AreEqual("Number1", node.Name.LocalName);
         }
+
+        [NUnit.Framework.Test]
+        public virtual void GetXfaFieldValue() {
+            String inFileName = sourceFolder + "TextField1.pdf";
+            PdfDocument pdfDocument = new PdfDocument(new PdfReader(inFileName));
+            PdfAcroForm acroForm = PdfAcroForm.GetAcroForm(pdfDocument, true);
+            XfaForm xfaForm = acroForm.GetXfaForm();
+            string value = xfaForm.GetXfaFieldValue("TextField1");
+            NUnit.Framework.Assert.AreEqual("Test", value);
+        }
     }
 }

--- a/itext/itext.forms/itext/forms/xfa/XfaForm.cs
+++ b/itext/itext.forms/itext/forms/xfa/XfaForm.cs
@@ -612,7 +612,7 @@ namespace iText.Forms.Xfa
 					    name += ((XText) n2).Value;
 					}
 				}
-			    n2 = ((XElement) n2).NextNode;
+			    n2 = n2.NextNode;
 			}
 			return name;
 		}


### PR DESCRIPTION
While iterating through sibling nodes, any XText element would throw
when the attempt was made to cast to XElement. Since NextNode is
declared in XNode anyway, the cast was not necessary to begin with.

This appears to have been introduced in the porting to .NET, the java code does not appear to need an equivalent fix.