### PR TITLE
Link Annotation - Goto Without Destination

### DIFF
--- a/itext/itext.kernel/itext/kernel/pdf/PdfCatalog.cs
+++ b/itext/itext.kernel/itext/kernel/pdf/PdfCatalog.cs
@@ -604,6 +604,7 @@ namespace iText.Kernel.Pdf {
 
         internal virtual PdfDestination CopyDestination(PdfObject dest, IDictionary<PdfPage, PdfPage> page2page, PdfDocument
              toDocument) {
+            if (dest == null) return null;
             PdfDestination d = null;
             if (dest.IsArray()) {
                 PdfObject pageObject = ((PdfArray)dest).Get(0);


### PR DESCRIPTION
I got my hands on a pdf file with a link annotation, but without any destination and I realized there's no validation for this scenario.