### PR TITLE
UriResolver.UriAsFileUrl fails with a UriFormatException if Directory.GetCurrentDirectory is /

### DIFF
--- a/itext/itext.styledxmlparser/itext/styledxmlparser/resolver/resource/UriResolver.cs
+++ b/itext/itext.styledxmlparser/itext/styledxmlparser/resolver/resource/UriResolver.cs
@@ -180,7 +180,7 @@ namespace iText.StyledXmlParser.Resolver.Resource
             if (baseUriString.Length == 0)
             {
                 isLocalBaseUri = true;
-                return new Uri(Directory.GetCurrentDirectory() + "/");
+                return new Uri(Path.Combine(Directory.GetCurrentDirectory(), "/"));
             }
             Uri baseAsFileUrl = null;
             try
@@ -191,7 +191,7 @@ namespace iText.StyledXmlParser.Resolver.Resource
                 }
                 else
                 {
-                    Uri baseUri = new Uri(Directory.GetCurrentDirectory() + "/");
+                    Uri baseUri = new Uri(Path.Combine(Directory.GetCurrentDirectory(), "/"));
                     baseAsFileUrl = new Uri(baseUri, NormalizeFilePath(baseUriString));
                 }
                 isLocalBaseUri = true;


### PR DESCRIPTION
UriResolver.UriAsFileUrl fails with a UriFormatException if Directory.GetCurrentDirectory is /

While an edge case, this is what `Directory.GetCurrentDirectory` returns on the Azure Functions runtime.
The old code using string concatenation would result in `//` which is an invalid URL while `Path.Combine(Directory.GetCurrentDirectory(), "/")` correctly results in a single `/`