### PR TITLE
Fix sanity check when null Field got no parent

### DIFF
--- a/itext/itext.forms/itext/forms/PdfAcroForm.cs
+++ b/itext/itext.forms/itext/forms/PdfAcroForm.cs
@@ -1034,6 +1034,9 @@ namespace iText.Forms {
                 String name;
                 if (fieldName == null) {
                     PdfFormField parentField = PdfFormField.MakeFormField(formField.GetParent(), document);
+                    if (parentField == null){
+                        continue;
+                    }
                     while (fieldName == null) {
                         fieldName = parentField.GetFieldName();
                         if (fieldName == null) {

--- a/itext/itext.forms/itext/forms/fields/PdfFormField.cs
+++ b/itext/itext.forms/itext/forms/fields/PdfFormField.cs
@@ -1646,7 +1646,7 @@ namespace iText.Forms.Fields {
         /// <c>pdfObject</c> does not contain a <c>FT</c> entry
         /// </returns>
         public static iText.Forms.Fields.PdfFormField MakeFormField(PdfObject pdfObject, PdfDocument document) {
-            if (pdfObject.IsDictionary()) {
+            if (pdfObject != null && pdfObject.IsDictionary()) {
                 iText.Forms.Fields.PdfFormField field;
                 PdfDictionary dictionary = (PdfDictionary)pdfObject;
                 PdfName formType = dictionary.GetAsName(PdfName.FT);


### PR DESCRIPTION
Just a little sanity check that discards ( behaviour that I have seen in other PDF libraries ) the fields ( and their childs ) that are null and got null parent.