### PR TITLE
Support custom element and newline separators in LocationTextExtractionStrategy

### DIFF
--- a/itext/itext.kernel/itext/kernel/pdf/canvas/parser/listener/LocationTextExtractionStrategy.cs
+++ b/itext/itext.kernel/itext/kernel/pdf/canvas/parser/listener/LocationTextExtractionStrategy.cs
@@ -45,6 +45,9 @@ namespace iText.Kernel.Pdf.Canvas.Parser.Listener {
 
         private TextRenderInfo lastTextRenderInfo;
 
+        private string elementSeparator = "";
+        private string newLine = "\n";
+
         /// <summary>Creates a new text extraction renderer.</summary>
         public LocationTextExtractionStrategy()
             : this(new LocationTextExtractionStrategy.ITextChunkLocationStrategyImpl()) {
@@ -58,6 +61,16 @@ namespace iText.Kernel.Pdf.Canvas.Parser.Listener {
         /// <param name="strat">the custom strategy</param>
         public LocationTextExtractionStrategy(LocationTextExtractionStrategy.ITextChunkLocationStrategy strat) {
             tclStrat = strat;
+        }
+
+        /// <summary>
+        /// Sets the string values used to separate elements and lines when formatting output.
+        /// </summary>
+        /// <param name="elementSeparator">The string to use as a separator between elements. Cannot be null.</param>
+        /// <param name="newLine">The string to use to represent a new line. Cannot be null.</param>
+        public void SetSeparators(string elementSeparator, string newLine) {
+            this.elementSeparator = elementSeparator; 
+            this.newLine = newLine;
         }
 
         /// <summary>
@@ -166,12 +179,12 @@ namespace iText.Kernel.Pdf.Canvas.Parser.Listener {
                         // we only insert a blank space if the trailing character of the previous string wasn't a space, and the leading character of the current string isn't a space
                         if (IsChunkAtWordBoundary(chunk, lastChunk) && !StartsWithSpace(chunk.text) && !EndsWithSpace(lastChunk.text
                             )) {
-                            sb.Append(' ');
+                            sb.Append(elementSeparator);
                         }
                         sb.Append(chunk.text);
                     }
                     else {
-                        sb.Append('\n');
+                        sb.Append(newLine);
                         sb.Append(chunk.text);
                     }
                 }


### PR DESCRIPTION
Based on existing LocationTextExtractionStrategy i needed more possibilities to distinguish between a "planned" space in text and the separator that was inserted when a new junk is found.
Same applies to the line feed.
Therefore i extended the LocationTextExtractionStrategy to use my own separators like pipes or other special characters.